### PR TITLE
Make ddf/dumpf more obvious in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Install as a dev dependency:
 
 ## Usage
 
-Just use `dd()` as you would normally, and enjoy the newly curated output! If, for some reason,
-you really need the full debug output for an object that `laravel-dumper` customizes, you can
+Just use `dd()` as you would normally, and enjoy the newly curated output!
+
+## Original Dump Output
+If, for some reason, you really need the full debug output for an object that `laravel-dumper` customizes, you can
 do a "full" dump with `ddf()` and `dumpf()`.
 
 ## Comparison to Default Output


### PR DESCRIPTION
I glossed over this a few times in the readme and only realised they were there after source diving and then checking the readme for the helpers I found.
This update just makes them a bit more obvious.