### PR TITLE
Allow usage of Lumen in Caster.php

### DIFF
--- a/src/Casters/Caster.php
+++ b/src/Casters/Caster.php
@@ -4,7 +4,6 @@ namespace Glhd\LaravelDumper\Casters;
 
 use Closure;
 use Glhd\LaravelDumper\Support\Properties;
-use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
@@ -14,12 +13,16 @@ abstract class Caster
 	
 	protected static bool $enabled = true;
 	
-	public static function register(Application $app): void
+	public static function register($app): void
 	{
-		$app->singleton(static::class);
+		if ($app instanceof Illuminate\Contracts\Foundation\Application || $app instanceof \Laravel\Lumen\Application) {
+			$app->singleton(static::class);
 		
-		foreach (static::$targets as $target) {
-			AbstractCloner::$defaultCasters[$target] = self::callback(static::class);
+			foreach (static::$targets as $target) {
+				AbstractCloner::$defaultCasters[$target] = self::callback(static::class);
+			}
+		} else {
+			// Maybe do some errorhandling here
 		}
 	}
 	

--- a/src/Casters/Caster.php
+++ b/src/Casters/Caster.php
@@ -4,6 +4,7 @@ namespace Glhd\LaravelDumper\Casters;
 
 use Closure;
 use Glhd\LaravelDumper\Support\Properties;
+use Illuminate\Contracts\Container\Container;
 use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
@@ -13,16 +14,12 @@ abstract class Caster
 	
 	protected static bool $enabled = true;
 	
-	public static function register($app): void
+	public static function register(Container $app): void
 	{
-		if ($app instanceof Illuminate\Contracts\Foundation\Application || $app instanceof \Laravel\Lumen\Application) {
-			$app->singleton(static::class);
+		$app->singleton(static::class);
 		
-			foreach (static::$targets as $target) {
-				AbstractCloner::$defaultCasters[$target] = self::callback(static::class);
-			}
-		} else {
-			// Maybe do some errorhandling here
+		foreach (static::$targets as $target) {
+			AbstractCloner::$defaultCasters[$target] = self::callback(static::class);
 		}
 	}
 	


### PR DESCRIPTION
Remove type hint for `Illuminate\Contracts\Foundation\Application` and also allowed `\Laravel\Lumen\Application.`
Error handling could be implemented, but is not necessary in my opinion

To use it in Lumen in `bootstrap/app.php` the following line should be added:

`$app->register(\Glhd\LaravelDumper\LaravelDumperServiceProvider::class);`

Fixes #9